### PR TITLE
Used an option object for plugin registration & added onNoTranslation callback

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,18 @@ var app = new Vue({
 
 ```
 
+You can specify a custom module name for vuex (default is 'i18n') or a callback that is triggered
+when a key has no translation for the current locale. Example:
+
+```javascript
+Vue.use(vuexI18n.plugin, store, {
+	moduleName: 'i18n',
+	onNoTranslation (key, locale) {
+		console.warn(`vuex-i18n :: Key '${key} not found for locale '${locale}'`);
+	}}
+);
+```
+
 ## Usage
 vuex-i18n provides easy access to localized information through the use of
 the `$t()` method or the `translate` filter.
@@ -142,8 +154,9 @@ Therefore it might be necessary to escape certain characters accordingly.
 
 ```javascript
 // i.e. to use {{count}} as variable substitution.
-// the third parameter defines the module name and is i18n per default
-Vue.use(vuexI18n.plugin, store, 'i18n', ['{{','}}']);
+Vue.use(vuexI18n.plugin, store, {
+	identifiers: ['{{','}}']
+});
 ```
 
 Basic pluralization is also supported. Please note, that the singular translation

--- a/src/vuex-i18n-plugin.js
+++ b/src/vuex-i18n-plugin.js
@@ -10,7 +10,19 @@ import plurals from './vuex-i18n-plurals';
 let VuexI18nPlugin = {};
 
 // internationalization plugin for vue js using vuex
-VuexI18nPlugin.install = function install(Vue, store, moduleName = 'i18n', identifiers = ['{', '}'], onNoTranslation) {
+VuexI18nPlugin.install = function install(Vue, store, config) {
+	// TODO: remove this block for next major update (API break)
+	if (typeof arguments[2] === 'string' || typeof arguments[3] === 'string') {
+		console.warn('VuexI18nPlugin: Registering the plugin with a string for `moduleName` or `identifiers` is deprecated. Use a configuration object instead.', 'https://github.com/dkfbasel/vuex-i18n#setup');
+		config = {
+			moduleName: arguments[2],
+			identifiers: arguments[3]
+		};
+	}
+	const { moduleName, identifiers, onNoTranslation } = Object.assign({
+		moduleName: 'i18n',
+		identifiers: ['{', '}']
+	}, config);
 
 	store.registerModule(moduleName, module);
 

--- a/src/vuex-i18n-plugin.js
+++ b/src/vuex-i18n-plugin.js
@@ -10,7 +10,7 @@ import plurals from './vuex-i18n-plurals';
 let VuexI18nPlugin = {};
 
 // internationalization plugin for vue js using vuex
-VuexI18nPlugin.install = function install(Vue, store, moduleName = 'i18n', identifiers = ['{', '}']) {
+VuexI18nPlugin.install = function install(Vue, store, moduleName = 'i18n', identifiers = ['{', '}'], onNoTranslation) {
 
 	store.registerModule(moduleName, module);
 
@@ -120,6 +120,10 @@ VuexI18nPlugin.install = function install(Vue, store, moduleName = 'i18n', ident
 		// return the value from the store
 		if (translationExist === true) {
 			return render(locale, translations[locale][key], options, pluralization);
+		} else {
+			if (typeof onNoTranslation === 'function') {
+				onNoTranslation(key, locale);
+			}
 		}
 
 		// check if a regional locale translation would be available for the key
@@ -375,3 +379,4 @@ function isArray(obj) {
 }
 
 export default VuexI18nPlugin;
+


### PR DESCRIPTION
This is a very naive implementation of a function that is called when a translation is not found for a given key and locale.

Example usage :
```js
Vue.use(VuexI18n.plugin, store, undefined, undefined, function (key, locale) {
  console.error(`vuex-i18n :: Key '${key} not found for locale '${locale}'`);
}
```