### PR TITLE
VueJs SSR: nodejs doesn't support console.group / console.groupEnd

### DIFF
--- a/src/vuex-i18n-plugin.js
+++ b/src/vuex-i18n-plugin.js
@@ -305,10 +305,12 @@ let renderFn = function(identifiers) {
 
 			// warn user that the placeholder has not been found
 			if (warn === true) {
-				console.group('Not all placeholders found');
+				console.group ? console.group('Not all placeholders found') : console.warn('Not all placeholders found');
 				console.warn('Text:', translation);
 				console.warn('Placeholder:', placeholder);
+				if(console.groupEnd) {
 				console.groupEnd();
+				}
 			}
 
 			// return the original placeholder


### PR DESCRIPTION
We are getting into the following error.

```
2017-09-11 12:55 +01:00: TypeError: console.group is not a function
18|X |     at /var/www/www.X.com/source/node_modules/vuex-i18n/dist/vuex-i18n.min.js:397:13
18|X |     at RegExp.[Symbol.replace] (native)
18|X |     at RegExp.[Symbol.replace] (native)
18|X |     at String.replace (native)
18|X |     at replace (/var/www/www.X.com/source/node_modules/vuex-i18n/dist/vuex-i18n.min.js:386:22)
18|X |     at replacedText (/var/www/www.X.com/source/node_modules/vuex-i18n/dist/vuex-i18n.min.js:428:12)
18|X |     at render (/var/www/www.X.com/source/node_modules/vuex-i18n/dist/vuex-i18n.min.js:434:11)
18|X |     at translateInLanguage (/var/www/www.X.com/source/node_modules/vuex-i18n/dist/vuex-i18n.min.js:238:11)
18|X |     at VueComponent.$t (/var/www/www.X.com/sou
```

This PR should fix the problem , but maybe you have a more beautiful way todo it 🥇 