### PR TITLE
Allow pluralization via arrays

### DIFF
--- a/dist/vuex-i18n.cjs.js
+++ b/dist/vuex-i18n.cjs.js
@@ -638,10 +638,12 @@ var renderFn = function renderFn(identifiers) {
 
 			// warn user that the placeholder has not been found
 			if (warn === true) {
-				console.group('Not all placeholders found');
+				console.group ? console.group('Not all placeholders found') : console.warn('Not all placeholders found');
 				console.warn('Text:', translation);
 				console.warn('Placeholder:', placeholder);
-				console.groupEnd();
+				if (console.groupEnd) {
+					console.groupEnd();
+				}
 			}
 
 			// return the original placeholder
@@ -659,7 +661,7 @@ var renderFn = function renderFn(identifiers) {
 		var objType = typeof translation === 'undefined' ? 'undefined' : _typeof(translation);
 		var pluralizationType = typeof pluralization === 'undefined' ? 'undefined' : _typeof(pluralization);
 
-		var replacedText = function replacedText() {
+		var replaceTranslation = function replaceTranslation() {
 
 			if (isArray$1(translation)) {
 
@@ -674,25 +676,26 @@ var renderFn = function renderFn(identifiers) {
 
 		// return translation item directly
 		if (pluralization === null) {
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check if pluralization value is countable
 		if (pluralizationType !== 'number') {
 			console.warn('pluralization is not a number');
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check for pluralization and return the correct part of the string
-		var translatedText = replacedText().split(':::');
+		var replacedTranslation = replaceTranslation();
+		var pluralizations = isArray$1(replacedTranslation) && replacedTranslation.length > 0 ? replacedTranslation : replacedTranslation.split(':::');
 		var index = plurals.getTranslationIndex(locale, pluralization);
 
-		if (typeof translatedText[index] === 'undefined') {
+		if (typeof pluralizations[index] === 'undefined') {
 			console.warn('no pluralized translation provided in ', translation);
-			return translatedText[0].trim();
-		} else {
-			return translatedText[index].trim();
+			index = 0;
 		}
+
+		return isArray$1(replacedTranslation) ? pluralizations[index] : pluralizations[index].trim();
 	};
 
 	// return the render function to the caller

--- a/dist/vuex-i18n.es.js
+++ b/dist/vuex-i18n.es.js
@@ -636,10 +636,12 @@ var renderFn = function renderFn(identifiers) {
 
 			// warn user that the placeholder has not been found
 			if (warn === true) {
-				console.group('Not all placeholders found');
+				console.group ? console.group('Not all placeholders found') : console.warn('Not all placeholders found');
 				console.warn('Text:', translation);
 				console.warn('Placeholder:', placeholder);
-				console.groupEnd();
+				if (console.groupEnd) {
+					console.groupEnd();
+				}
 			}
 
 			// return the original placeholder
@@ -657,7 +659,7 @@ var renderFn = function renderFn(identifiers) {
 		var objType = typeof translation === 'undefined' ? 'undefined' : _typeof(translation);
 		var pluralizationType = typeof pluralization === 'undefined' ? 'undefined' : _typeof(pluralization);
 
-		var replacedText = function replacedText() {
+		var replaceTranslation = function replaceTranslation() {
 
 			if (isArray$1(translation)) {
 
@@ -672,25 +674,26 @@ var renderFn = function renderFn(identifiers) {
 
 		// return translation item directly
 		if (pluralization === null) {
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check if pluralization value is countable
 		if (pluralizationType !== 'number') {
 			console.warn('pluralization is not a number');
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check for pluralization and return the correct part of the string
-		var translatedText = replacedText().split(':::');
+		var replacedTranslation = replaceTranslation();
+		var pluralizations = isArray$1(replacedTranslation) && replacedTranslation.length > 0 ? replacedTranslation : replacedTranslation.split(':::');
 		var index = plurals.getTranslationIndex(locale, pluralization);
 
-		if (typeof translatedText[index] === 'undefined') {
+		if (typeof pluralizations[index] === 'undefined') {
 			console.warn('no pluralized translation provided in ', translation);
-			return translatedText[0].trim();
-		} else {
-			return translatedText[index].trim();
+			index = 0;
 		}
+
+		return isArray$1(replacedTranslation) ? pluralizations[index] : pluralizations[index].trim();
 	};
 
 	// return the render function to the caller

--- a/dist/vuex-i18n.min.js
+++ b/dist/vuex-i18n.min.js
@@ -642,10 +642,12 @@ var renderFn = function renderFn(identifiers) {
 
 			// warn user that the placeholder has not been found
 			if (warn === true) {
-				console.group('Not all placeholders found');
+				console.group ? console.group('Not all placeholders found') : console.warn('Not all placeholders found');
 				console.warn('Text:', translation);
 				console.warn('Placeholder:', placeholder);
-				console.groupEnd();
+				if (console.groupEnd) {
+					console.groupEnd();
+				}
 			}
 
 			// return the original placeholder
@@ -663,7 +665,7 @@ var renderFn = function renderFn(identifiers) {
 		var objType = typeof translation === 'undefined' ? 'undefined' : _typeof(translation);
 		var pluralizationType = typeof pluralization === 'undefined' ? 'undefined' : _typeof(pluralization);
 
-		var replacedText = function replacedText() {
+		var replaceTranslation = function replaceTranslation() {
 
 			if (isArray$1(translation)) {
 
@@ -678,25 +680,26 @@ var renderFn = function renderFn(identifiers) {
 
 		// return translation item directly
 		if (pluralization === null) {
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check if pluralization value is countable
 		if (pluralizationType !== 'number') {
 			console.warn('pluralization is not a number');
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check for pluralization and return the correct part of the string
-		var translatedText = replacedText().split(':::');
+		var replacedTranslation = replaceTranslation();
+		var pluralizations = isArray$1(replacedTranslation) && replacedTranslation.length > 0 ? replacedTranslation : replacedTranslation.split(':::');
 		var index = plurals.getTranslationIndex(locale, pluralization);
 
-		if (typeof translatedText[index] === 'undefined') {
+		if (typeof pluralizations[index] === 'undefined') {
 			console.warn('no pluralized translation provided in ', translation);
-			return translatedText[0].trim();
-		} else {
-			return translatedText[index].trim();
+			index = 0;
 		}
+
+		return isArray$1(replacedTranslation) ? pluralizations[index] : pluralizations[index].trim();
 	};
 
 	// return the render function to the caller

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-i18n",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Easy localization for vue-components using vuex as data store",
   "directories": {
     "test": "test"

--- a/src/vuex-i18n-plugin.js
+++ b/src/vuex-i18n-plugin.js
@@ -325,7 +325,7 @@ let renderFn = function(identifiers) {
 		let objType = typeof translation;
 		let pluralizationType = typeof pluralization;
 
-		let replacedText = function() {
+		let replaceTranslation = function() {
 
 			if (isArray(translation)) {
 
@@ -340,28 +340,28 @@ let renderFn = function(identifiers) {
 
 		};
 
-			// return translation item directly
+		// return translation item directly
 		if (pluralization === null) {
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check if pluralization value is countable
 		if (pluralizationType !== 'number') {
 			console.warn('pluralization is not a number');
-			return replacedText();
+			return replaceTranslation();
 		}
 
 		// check for pluralization and return the correct part of the string
-		let translatedText = replacedText().split(':::');
+		let replacedTranslation = replaceTranslation();
+		let pluralizations = isArray(replacedTranslation) && replacedTranslation.length > 0 ? replacedTranslation : replacedTranslation.split(':::');
 		let index = plurals.getTranslationIndex(locale, pluralization);
 
-		if(typeof translatedText[index] === 'undefined') {
+		if (typeof pluralizations[index] === 'undefined') {
 			console.warn('no pluralized translation provided in ', translation);
-			return translatedText[0].trim();
+			index = 0;
 		}
-		else {
-			return translatedText[index].trim();
-		}
+
+		return isArray(replacedTranslation) ? pluralizations[index] : pluralizations[index].trim();
 	};
 
 	// return the render function to the caller


### PR DESCRIPTION
```
$i18n.add('en', {'comments': [
    '{count} comment',
    '{count} comments',
]});

$i18n.add('ru', {'comments': [
    '{count} комментарий',
    '{count} комментария',
    '{count} комментариев',
]});

$i18n.set('en');
$t('comments', {count: 5}, 5); // 5 comments

$i18n.set('ru');
$t('comments', {count: 5}, 5); // 5 комментариев
```