### PR TITLE
add translateFilterName config

### DIFF
--- a/src/vuex-i18n-plugin.js
+++ b/src/vuex-i18n-plugin.js
@@ -26,12 +26,14 @@ VuexI18nPlugin.install = function install(Vue, store, config) {
 		moduleName: 'i18n',
 		identifiers: ['{', '}'],
 		preserveState: false,
+		translateFilterName: 'translate',
 		onTranslationNotFound: function() {}
 	}, config);
 
 	// define module name and identifiers as constants to prevent any changes
 	const moduleName = mergedConfig.moduleName;
 	const identifiers = mergedConfig.identifiers;
+	const translateFilterName = mergedConfig.translateFilterName;
 
 	// initialize the onTranslationNotFound function and make sure it is actually
 	// a function
@@ -342,7 +344,7 @@ VuexI18nPlugin.install = function install(Vue, store, config) {
 	Vue.prototype.$tlang = translateInLanguage;
 
 	// register a filter function for translations
-	Vue.filter('translate', translate);
+	Vue.filter(translateFilterName, translate);
 
 };
 


### PR DESCRIPTION
Hi, I like this plugin and I plan to use it in my projects. However, the name of translate filter function is fixed as 'translate'. I think this is not a good idea, so, I suggest putting the 'translatFilterName' in the config. This will be more flexible!
Thank you for the plugin, and I hope my pull request will be accepted!