### PR TITLE
Fix variable substitution matching

### DIFF
--- a/src/vuex-i18n-plugin.js
+++ b/src/vuex-i18n-plugin.js
@@ -361,7 +361,7 @@ let renderFn = function(identifiers, warnings = true) {
 	}
 
 	// construct a regular expression ot find variable substitutions, i.e. {test}
-	let matcher = new RegExp('' + identifiers[0] + '{1}\\w.+?' + identifiers[1] + '{1}', 'g');
+	let matcher = new RegExp('' + identifiers[0] + '{1}[\\w.]+?' + identifiers[1] + '{1}', 'g');
 
 	// define the replacement function
 	let replace = function replace(translation, replacements) {


### PR DESCRIPTION
Previously it would only match if the name for a variable was at least two characters long, due to the `\w` and `.` identifiers. This solution will also match dots that could be in the identifier - although i'm not sure if that's correct.